### PR TITLE
docker uplift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,5 @@ docker-compose*
 README.md
 LICENSE
 .vscode
+.idea
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM openjdk:8-jdk-alpine
-ARG JAVA_OPTS
-ENV JAVA_OPTS=$JAVA_OPTS
-ADD target/xe_light-1.0-SNAPSHOT.jar xe_light.jar
+FROM java:7
+LABEL maintainer="DataseekCN"
+RUN apt-get update -qq && apt-get install -y maven && apt-get clean
+WORKDIR /app
+ADD pom.xml /app/pom.xml
+RUN ["mvn", "dependency:resolve"]
+RUN ["mvn", "verify"]
+
+ADD src /app/src
+RUN ["mvn", "package"]
 EXPOSE 12006
-# ENTRYPOINT exec java $JAVA_OPTS -jar xe_light.jar
-# For Spring-Boot project, use the entrypoint below to reduce Tomcat startup time.
-ENTRYPOINT exec java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar xe_light.jar
+
+CMD ["/usr/lib/jvm/java-7-openjdk-amd64/bin/java", "-jar", "target/worker-jar-with-dependencies.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: image
+image:
+	docker build -t dataseek/xe_light .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '2.1'
+version: '3'
 
 services:
   xe_light:
-    image: xe_light
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
     ports:
       - 12006:12006


### PR DESCRIPTION
这个PR包含了如下的改动：
- [x] 修改`Dockerfile`，修复了引用dockerfile无法构建镜像的问题；
- [x] 添加`Makefile`中`image`指令，使得构建docker镜像可通过`make image`快速执行；
- [x] 添加`.dockerignore`使得构建镜像过程忽略无关文件；
- [x] 添加`docker-compose.yml`文件，`docker-compose up -d`可以快速部署； 

## 现存问题
构建镜像过程中部分maven依赖无法获取。